### PR TITLE
Remove register storage class specifier for C++17 compatibility

### DIFF
--- a/src/coxformatrices.cpp
+++ b/src/coxformatrices.cpp
@@ -525,8 +525,8 @@ int cholesky2(double **matrix, int n, double toler)
 
 void chsolve2(double **matrix, int n, double *y)
 {
-    register int i,j;
-    register double temp;
+    int i,j;
+    double temp;
     
     /*
      ** solve Fb =y
@@ -566,8 +566,8 @@ void chsolve2(double **matrix, int n, double *y)
 
 void chinv2(double **matrix , int n)
 {
-    register double temp;
-    register int i,j,k;
+    double temp;
+    int i,j,k;
     
     /*
      ** invert the cholesky in the lower triangle
@@ -653,8 +653,8 @@ double coxsafe(double x) {
 double **dmatrix(double *array, int ncol, int nrow)
 {
     S_EVALUATOR
-    register int i;
-    register double **pointer;
+    int i;
+    double **pointer;
     
     pointer = (double **) ALLOC(nrow, sizeof(double *));
     for (i=0; i<nrow; i++) {


### PR DESCRIPTION
This fixes the build on recent R versions that use clang, see:

 - https://github.com/r-universe/bioc/actions/runs/30404207841/job/90427215349
 - https://github.com/r-universe/bioc-release/actions/runs/30404267062/job/90539993124

We simply remove `register` which is no longer supported as of C++17

@SydneyBioX this will unblock dependent packages [scFeatures](https://bioc.r-universe.dev/scFeatures) [spicyR](https://bioc.r-universe.dev/spicyR) [Statial](https://bioc.r-universe.dev/Statial) [TOP](https://bioc.r-universe.dev/TOP) from building on these platforms.